### PR TITLE
fix: fixed publishing in pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   tests:
@@ -54,4 +55,3 @@ jobs:
           git config --global user.email "semantic-release@users.noreply.github.com"
           poetry run semantic-release version
           poetry run semantic-release publish
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,10 @@ jobs:
           git config --global user.name "semantic-release"
           git config --global user.email "semantic-release@users.noreply.github.com"
           poetry run semantic-release version
+          poetry run semantic-release publish
           poetry build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
-        if: steps.semantic-release.outcome == 'success'
         with:
           packages-dir: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           poetry build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         if: steps.semantic-release.outcome == 'success'
         with:
           packages-dir: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,4 +54,10 @@ jobs:
           git config --global user.name "semantic-release"
           git config --global user.email "semantic-release@users.noreply.github.com"
           poetry run semantic-release version
-          poetry run semantic-release publish
+          poetry build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: steps.semantic-release.outcome == 'success'
+        with:
+          packages-dir: dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,4 +109,3 @@ prerelease = false
 [tool.semantic_release.publish]
 dist_glob_patterns = ["dist/*"]
 upload_to_vcs_release = true
-upload_to_pypi = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ markers = [
 version_toml = ["pyproject.toml:tool.poetry.version"]
 build_command = "poetry build"
 dist_path = "dist/"
-upload_to_pypi = true
 upload_to_release = true
 remove_dist = false
 commit_author = "semantic-release <semantic-release>"
@@ -103,5 +102,11 @@ tag_format = "{version}"
 commit_parser = "conventional"
 changelog_file = "CHANGELOG.md"
 
+[tool.semantic_release.branches.main]
+match = "main"
+prerelease = false
+
 [tool.semantic_release.publish]
 dist_glob_patterns = ["dist/*"]
+upload_to_vcs_release = true
+upload_to_pypi = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * CI release workflow updated to use modern OIDC/id-token permissions, adds a build step before publishing, and adds a dedicated PyPI publish step that targets built distributions.
  * Release settings adjusted: explicit main-branch behavior (no prereleases) and releases now also publish artifacts to VCS.
  * No user-facing app changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->