### PR TITLE
feat: added field as contenttype

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -86,7 +86,8 @@ Content Transformer Plugins
 
 .. versionadded:: 1.5.0
 
-The three content types are ``"post"``, ``"page"``, and ``"comment"``.
+Available content types are defined in :data:`platzky.content_types.ContentType`.
+See :ref:`field-rendering` below for the meaning of ``"field"``.
 
 .. code-block:: python
 
@@ -145,6 +146,27 @@ Declare ``shortcodes`` as a class variable:
 
         accepted_content_types: frozenset[ContentType] = frozenset({"post", "page"})
         shortcodes: ClassVar[dict[str, Shortcode]] = {"alert": _AlertShortcode()}
+
+.. _field-rendering:
+
+**Field rendering**
+
+A shortcode's :meth:`~platzky.shortcodes.Shortcode.transform_field_value` method
+is called by host applications (such as Goodmap) to transform a structured field
+value into a frontend-ready dict, rather than rendering HTML from post content.
+
+To opt a plugin's shortcodes in to field rendering, include ``"field"`` in
+``accepted_content_types``:
+
+.. code-block:: python
+
+    class MyPlugin(ContentTransformerPluginBase):
+        accepted_content_types: frozenset[ContentType] = frozenset({"post", "page", "field"})
+
+To opt out — for example a purely cosmetic shortcode that has no meaningful field
+representation — simply omit ``"field"`` from the set. Host applications must
+also grant the plugin permission via ``allowed_content_types`` in the database
+config (see :ref:`plugin-configuration`).
 
 **Built-in shortcodes**
 
@@ -213,6 +235,8 @@ plugin class in ``pyproject.toml``:
 
 The key (``my_plugin``) is the name used in the database configuration.
 
+.. _plugin-configuration:
+
 Plugin Configuration
 --------------------
 
@@ -242,14 +266,16 @@ For notifier plugins you can restrict which topics the plugin receives:
         "allowed_topics": ["security", "general"]
     }
 
-For content transformer plugins you can restrict which content types are processed:
+For content transformer plugins you can restrict which content types are processed.
+Include ``"field"`` to also allow the plugin's shortcodes to be used for field
+rendering by host applications:
 
 .. code-block:: json
 
     {
         "name": "alert_plugin",
         "config": {},
-        "allowed_content_types": ["post", "page"]
+        "allowed_content_types": ["post", "page", "field"]
     }
 
 Admin Help Page

--- a/platzky/content_types.py
+++ b/platzky/content_types.py
@@ -2,5 +2,5 @@
 
 from typing import Literal, get_args
 
-ContentType = Literal["post", "page", "comment"]
+ContentType = Literal["post", "page", "comment", "field"]
 ALL_CONTENT_TYPES: frozenset[ContentType] = frozenset(get_args(ContentType))

--- a/tests/unit_tests/plugin/test_plugin_bases.py
+++ b/tests/unit_tests/plugin/test_plugin_bases.py
@@ -455,3 +455,41 @@ class TestContentTransformerWiring:
         """get_jinja_extensions() classes must appear in engine.jinja_env.extensions."""
         app = _app_with_plugin(base_config_data, "jinjaext", JinjaExtPlugin)
         assert any("_DummyJinjaExtension" in k for k in app.jinja_env.extensions)
+
+
+# ---------------------------------------------------------------------------
+# ContentType "field" — field-rendering opt-in
+# ---------------------------------------------------------------------------
+
+
+class TestFieldContentType:
+    def test_field_in_all_content_types(self) -> None:
+        assert "field" in ALL_CONTENT_TYPES
+
+    def test_plugin_with_field_processes_field_content(
+        self, base_config_data: dict[str, Any]
+    ) -> None:
+        class FieldReadyFilter(ContentTransformerPluginBase):
+            def __init__(self, config: dict[str, Any]) -> None:
+                super().__init__(config)
+                self.accepted_content_types: frozenset[ContentType] = frozenset({"field"})
+
+            def transform_text(self, text: str) -> str:
+                return text + "[field]"
+
+        app = _app_with_plugin(base_config_data, "fieldready", FieldReadyFilter)
+        assert app.transform_content("x", "field") == "x[field]"
+
+    def test_plugin_without_field_skips_field_content(
+        self, base_config_data: dict[str, Any]
+    ) -> None:
+        class PostOnlyFilter(ContentTransformerPluginBase):
+            def __init__(self, config: dict[str, Any]) -> None:
+                super().__init__(config)
+                self.accepted_content_types: frozenset[ContentType] = frozenset({"post"})
+
+            def transform_text(self, text: str) -> str:
+                return text + "[post]"
+
+        app = _app_with_plugin(base_config_data, "postonlyfilter", PostOnlyFilter)
+        assert app.transform_content("x", "field") == "x"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new "field" content type, now treated alongside posts, pages, and comments.

* **Documentation**
  * Clarified content-type options and added a "Field rendering" section with configuration examples for opting into field rendering.

* **Tests**
  * Added tests to verify "field" is recognized and that plugins opt-in/out of processing field content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->