### PR TITLE
refactor: improve database loading and add thread-local GraphQL client with locale domain matching

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -166,6 +166,14 @@ Each language configuration includes:
         country: DE
         domain: example.de  # Optional: language-specific domain for redirects
 
+When a language has a ``domain``, a fresh visitor (no language chosen yet) landing
+directly on that domain sees that language, taking priority over Accept-Language
+guessing. Matching ignores port, case, and a trailing dot, so ``domain: example.de``
+matches requests to ``example.de``, ``EXAMPLE.DE``, ``example.de:8443``, or
+``example.de.``. Include a port in ``domain`` (e.g. ``domain: example.de:5000``) if
+the language's domain is only reachable on a non-standard port, such as in local or
+staging setups.
+
 ``TRANSLATION_DIRECTORIES``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -257,6 +257,23 @@ inject at the start of ``<body>``. Only sections declared in ``accepted_page_sec
 **and** permitted by ``allowed_page_sections`` in the database config are injected —
 neither side alone controls what gets rendered.
 
+Accessing the Engine from Request Handlers
+-------------------------------------------
+
+Flask's own ``current_app`` proxy is typed as plain ``Flask``, so it doesn't expose
+Engine-specific methods like ``notify`` or ``is_enabled`` to a type checker. If a
+plugin registers its own routes and needs the Engine from inside a view function
+(where ``app`` isn't otherwise in scope), use :func:`platzky.current_engine` instead:
+
+.. code-block:: python
+
+    from platzky import current_engine
+
+    @blueprint.route("/webhook", methods=["POST"])
+    def handle_webhook():
+        current_engine().notify("Webhook received", topic="general")
+        return "", 204
+
 Packaging a Plugin
 ------------------
 

--- a/platzky/__init__.py
+++ b/platzky/__init__.py
@@ -3,6 +3,7 @@ from platzky.auth import User as User
 from platzky.content_types import ALL_CONTENT_TYPES as ALL_CONTENT_TYPES
 from platzky.content_types import ContentType as ContentType
 from platzky.engine import Engine as Engine
+from platzky.engine import current_engine as current_engine
 from platzky.feature_flags import BUILTIN_FLAGS as BUILTIN_FLAGS
 from platzky.feature_flags import FakeLogin as FakeLogin
 from platzky.feature_flags import FeatureFlag as FeatureFlag

--- a/platzky/db/db_loader.py
+++ b/platzky/db/db_loader.py
@@ -1,10 +1,7 @@
 """Dynamic database module loader based on configuration type."""
 
-import importlib.util
-import os
-import sys
+import importlib
 import types
-from os.path import abspath, dirname
 
 from platzky.db.db import DB, DBConfig
 
@@ -18,21 +15,9 @@ def get_db(db_config: DBConfig) -> DB:
 
 def get_db_module(db_type: str) -> types.ModuleType:
     """
-    Load db module from db_type
-    This function is used to load db module dynamically as it is specified in config file.
+    Import the db module for db_type from the platzky.db package.
     :param db_type: name of db module
     :return: db module
     """
-    db_dir = dirname(abspath(__file__))
     parent_module_name = ".".join(__name__.split(".")[:-1])
-    module_name = f"{parent_module_name}.{db_type}_db"
-    spec = importlib.util.spec_from_file_location(
-        module_name, os.path.join(db_dir, f"{db_type}_db.py")
-    )
-    assert spec is not None
-    db = importlib.util.module_from_spec(spec)
-    sys.modules[f"{db_type}_db"] = db
-    assert spec.loader is not None
-    spec.loader.exec_module(db)
-
-    return db
+    return importlib.import_module(f"{parent_module_name}.{db_type}_db")

--- a/platzky/db/graph_ql_db.py
+++ b/platzky/db/graph_ql_db.py
@@ -272,6 +272,9 @@ class GraphQL(DB):
 
         Returns:
             Page object
+
+        Raises:
+            ValueError: If no page exists for the given slug.
         """
         page_query = gql("""
             query MyQuery ($slug: String!){
@@ -287,6 +290,8 @@ class GraphQL(DB):
             }
             """)
         page_raw = self.client.execute(page_query, variable_values={"slug": slug})["page"]
+        if page_raw is None:
+            raise ValueError(f"Page not found: {slug}")
         return Page.model_validate(_standardize_page(page_raw))
 
     def get_posts_by_tag(self, tag: str, lang: str) -> list[Post]:
@@ -448,7 +453,15 @@ class GraphQL(DB):
         return "navy"  # Default color as string
 
     def get_plugins_data(self) -> dict[str, PluginConfigBase]:
-        """Retrieve configuration data for all plugins."""
+        """Retrieve configuration data for all plugins.
+
+        Hygraph's PluginConfig schema only exposes ``name``, ``isActive``, and
+        ``config`` (a JSON scalar) — there's no room for a sibling field like
+        ``allowed_content_types``. Authors put permission fields directly
+        inside the ``config`` JSON instead; this spreads ``config``'s keys to
+        the top level so the engine's capability-specific config classes
+        (``ContentTransformerPluginConfig``, etc.) can find them by name.
+        """
         plugins_data = gql("""
             query MyQuery {
               pluginConfigs(stage: PUBLISHED) {
@@ -459,7 +472,10 @@ class GraphQL(DB):
             }
             """)
         raw = self.client.execute(plugins_data)["pluginConfigs"]
-        return {d["name"]: PluginConfigBase.model_validate(d) for d in raw}
+        return {
+            d["name"]: PluginConfigBase.model_validate({**(d.get("config") or {}), **d})
+            for d in raw
+        }
 
     def health_check(self) -> None:
         """Perform a health check on the GraphQL database.

--- a/platzky/db/graph_ql_db.py
+++ b/platzky/db/graph_ql_db.py
@@ -2,6 +2,7 @@
 
 # TODO: Rename file, extract to another library, remove gql and aiohttp from dependencies
 
+import threading
 from typing import Any
 
 from gql import Client, gql
@@ -152,10 +153,29 @@ class GraphQL(DB):
         """
         self.module_name = "graph_ql_db"
         self.db_name = "GraphQLDb"
-        full_token = "bearer " + token
-        transport = AIOHTTPTransport(url=endpoint, headers={"Authorization": full_token})
-        self.client = Client(transport=transport)
+        self._endpoint = endpoint
+        self._headers = {"Authorization": "bearer " + token}
+        self._local = threading.local()
         super().__init__()
+
+    def __getattr__(self, name: str) -> Client:
+        """Lazily build this thread's GraphQL client on first access to ``client``.
+
+        AIOHTTPTransport's connect/close cycle tracks a single session flag per
+        transport instance; sharing one Client across threads lets a second
+        thread's connect() race a first thread's still-open session, raising
+        TransportAlreadyConnected. A client per thread avoids that. Implemented via
+        __getattr__ rather than a property because DB.__init_subclass__ forbids
+        subclasses from adding public class-level names not in the DB interface.
+        """
+        if name != "client":
+            raise AttributeError(name)
+        client = getattr(self._local, "client", None)
+        if client is None:
+            transport = AIOHTTPTransport(url=self._endpoint, headers=self._headers)
+            client = Client(transport=transport)
+            self._local.client = client
+        return client
 
     def get_all_posts(self, lang: str) -> list[Post]:
         """Retrieve all published posts for a specific language.

--- a/platzky/engine.py
+++ b/platzky/engine.py
@@ -351,8 +351,10 @@ class Engine(Flask):
         fresh visitor (no session yet) landing directly on that domain sees the
         language it represents, rather than whatever their browser prefers.
         """
+        normalized_host = host.split(":", 1)[0].rstrip(".").lower()
         for lang, cfg in languages.items():
-            if cfg.get("domain") == host:
+            domain = cfg.get("domain")
+            if isinstance(domain, str) and domain.rstrip(".").lower() == normalized_host:
                 return lang
         return None
 

--- a/platzky/engine.py
+++ b/platzky/engine.py
@@ -352,13 +352,18 @@ class Engine(Flask):
         fresh visitor (no session yet) landing directly on that domain sees the
         language it represents, rather than whatever their browser prefers.
         """
-        normalized_host = host.split(":", 1)[0].rstrip(".").lower()
+        host_without_port = host.split(":", 1)[0].rstrip(".").lower()
+        host_with_port = host.rstrip(".").lower()
         for lang, cfg in languages.items():
             domain = cfg.get("domain")
-            normalized_domain = (
-                domain.split(":", 1)[0].rstrip(".").lower() if isinstance(domain, str) else None
-            )
-            if normalized_domain == normalized_host:
+            if not isinstance(domain, str):
+                continue
+            normalized_domain = domain.rstrip(".").lower()
+            # A domain with an explicit port must match the host's port exactly; a
+            # domain without one matches regardless of port (e.g. behind a proxy
+            # that forwards on a non-standard port).
+            host_to_compare = host_with_port if ":" in normalized_domain else host_without_port
+            if normalized_domain == host_to_compare:
                 return lang
         return None
 

--- a/platzky/engine.py
+++ b/platzky/engine.py
@@ -7,7 +7,7 @@ import threading
 from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import Future, TimeoutError
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from platzky.plugin.html_injector import PageSection
@@ -329,17 +329,32 @@ class Engine(Flask):
         self.dynamic_head += head
 
     def get_locale(self) -> str:
-        """Return the current locale based on session or browser preferences."""
-        languages = self.config.get("LANGUAGES", {}).keys()
+        """Return the current locale based on session, host domain, or browser preferences."""
+        languages = self.config.get("LANGUAGES", {})
 
         session_lang = session.get("language")
         if isinstance(session_lang, str) and session_lang in languages:
             lang = session_lang
         else:
-            lang = request.accept_languages.best_match(languages) or "en"
+            lang = self._language_for_host(languages, request.host) or (
+                request.accept_languages.best_match(languages.keys()) or "en"
+            )
 
         session["language"] = lang
         return lang
+
+    @staticmethod
+    def _language_for_host(languages: dict[str, Any], host: str) -> Optional[str]:
+        """Return the language code whose dedicated domain matches host, if any.
+
+        A language's own domain takes priority over Accept-Language guessing so a
+        fresh visitor (no session yet) landing directly on that domain sees the
+        language it represents, rather than whatever their browser prefers.
+        """
+        for lang, cfg in languages.items():
+            if cfg.get("domain") == host:
+                return lang
+        return None
 
     def is_enabled(self, flag: FeatureFlag) -> bool:
         """Check whether a feature flag is enabled.

--- a/platzky/engine.py
+++ b/platzky/engine.py
@@ -7,7 +7,7 @@ import threading
 from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import Future, TimeoutError
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 if TYPE_CHECKING:
     from platzky.plugin.html_injector import PageSection
@@ -17,6 +17,7 @@ from flask import (
     Blueprint,
     Flask,
     Response,
+    current_app,
     jsonify,
     make_response,
     request,
@@ -354,7 +355,10 @@ class Engine(Flask):
         normalized_host = host.split(":", 1)[0].rstrip(".").lower()
         for lang, cfg in languages.items():
             domain = cfg.get("domain")
-            if isinstance(domain, str) and domain.rstrip(".").lower() == normalized_host:
+            normalized_domain = (
+                domain.split(":", 1)[0].rstrip(".").lower() if isinstance(domain, str) else None
+            )
+            if normalized_domain == normalized_host:
                 return lang
         return None
 
@@ -443,3 +447,13 @@ class Engine(Flask):
             return liveness()
 
         self.register_blueprint(health_bp)
+
+
+def current_engine() -> Engine:
+    """Return Flask's current_app typed as Engine.
+
+    Returns:
+        The active application, which is always an Engine instance since
+        create_app() is the only entry point that constructs it.
+    """
+    return cast(Engine, current_app)

--- a/platzky/templates/base.html
+++ b/platzky/templates/base.html
@@ -73,7 +73,7 @@
             <div id="language-dropdown" class="btn-group">
               <button type="button" class="nav-link dropdown-toggle btn btn-link" id="languages-menu"
                       data-bs-toggle="dropdown" aria-expanded="false" aria-label="{{ _("Language switch icon, used to change the language of the website")}}">
-                <span class="language-indicator-text">{{ current_language }}</i>
+                <span class="language-indicator-text">{{ current_language }}</span>
                 <i class="fi fi-{{ current_flag }}"></i>
               </button>
               <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="languages-menu">

--- a/platzky/templates/body_meta.html
+++ b/platzky/templates/body_meta.html
@@ -3,4 +3,4 @@
 <!-- Optional JavaScript -->
 <!-- jQuery first, then Popper.js, then Bootstrap JS -->
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc4s9bIOgUxi8T/jzmT9JGbPJ8RjBg6qPEJ4SBJ7eR1" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>

--- a/tests/e2e_tests/cypress/e2e/language_test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/language_test.cy.js
@@ -1,0 +1,13 @@
+describe('Language switcher', () => {
+  it('changes the displayed language when a different option is selected', () => {
+    cy.visit('/blog/')
+    cy.get('#languages-menu').should('contain.text', 'en')
+    cy.contains('.nav-link', 'Home')
+
+    cy.get('#languages-menu').click()
+    cy.contains('.dropdown-item', 'polski').click()
+
+    cy.get('#languages-menu').should('contain.text', 'pl')
+    cy.contains('.nav-link', 'Strona domowa')
+  })
+})

--- a/tests/e2e_tests/cypress/e2e/simple_test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/simple_test.cy.js
@@ -57,7 +57,6 @@ describe('Blog test', () => {
 
 // TODO add tests:
 //   - post and page without image
-//   - translations
 //
 
 })

--- a/tests/unit_tests/db/test_graph_ql_db.py
+++ b/tests/unit_tests/db/test_graph_ql_db.py
@@ -80,6 +80,7 @@ def test_graph_ql_client_is_per_thread():
     thread.join()
 
     assert db.client is main_thread_client
+    assert len(other_thread_client) == 1
     assert other_thread_client[0] is not main_thread_client
 
 

--- a/tests/unit_tests/db/test_graph_ql_db.py
+++ b/tests/unit_tests/db/test_graph_ql_db.py
@@ -74,13 +74,22 @@ def test_graph_ql_client_is_per_thread():
     )  # NOSONAR - hardcoded token acceptable in tests
 
     main_thread_client = db.client
-    other_thread_client: list[Client] = []
-    thread = threading.Thread(target=lambda: other_thread_client.append(db.client))
+    other_thread_client: list[Client | BaseException] = []
+
+    def get_client_in_thread():
+        try:
+            other_thread_client.append(db.client)
+        except BaseException as e:
+            other_thread_client.append(e)
+
+    thread = threading.Thread(target=get_client_in_thread)
     thread.start()
     thread.join()
 
+    assert len(other_thread_client) == 1, "Thread did not complete"
+    if isinstance(other_thread_client[0], BaseException):
+        raise other_thread_client[0]
     assert db.client is main_thread_client
-    assert len(other_thread_client) == 1
     assert other_thread_client[0] is not main_thread_client
 
 

--- a/tests/unit_tests/db/test_graph_ql_db.py
+++ b/tests/unit_tests/db/test_graph_ql_db.py
@@ -74,12 +74,12 @@ def test_graph_ql_client_is_per_thread():
     )  # NOSONAR - hardcoded token acceptable in tests
 
     main_thread_client = db.client
-    other_thread_client: list[Client | BaseException] = []
+    other_thread_client: list[Client | Exception] = []
 
     def get_client_in_thread():
         try:
             other_thread_client.append(db.client)
-        except BaseException as e:
+        except Exception as e:
             other_thread_client.append(e)
 
     thread = threading.Thread(target=get_client_in_thread)
@@ -87,7 +87,7 @@ def test_graph_ql_client_is_per_thread():
     thread.join()
 
     assert len(other_thread_client) == 1, "Thread did not complete"
-    if isinstance(other_thread_client[0], BaseException):
+    if isinstance(other_thread_client[0], Exception):
         raise other_thread_client[0]
     assert db.client is main_thread_client
     assert other_thread_client[0] is not main_thread_client

--- a/tests/unit_tests/db/test_graph_ql_db.py
+++ b/tests/unit_tests/db/test_graph_ql_db.py
@@ -162,6 +162,13 @@ def test_get_page(graph_ql_db: GraphQL, mock_client: Mock):
     mock_client.execute.assert_called_once()
 
 
+def test_get_page_not_found(graph_ql_db: GraphQL, mock_client: Mock):
+    mock_client.execute.return_value = {"page": None}
+
+    with pytest.raises(ValueError, match="missing"):
+        graph_ql_db.get_page("missing")
+
+
 def test_get_posts_by_tag(graph_ql_db: GraphQL, mock_client: Mock):
     mock_response = {
         "posts": [

--- a/tests/unit_tests/db/test_graph_ql_db.py
+++ b/tests/unit_tests/db/test_graph_ql_db.py
@@ -1,6 +1,8 @@
+import threading
 from unittest.mock import Mock, patch
 
 import pytest
+from gql import Client
 
 from platzky.db.graph_ql_db import (
     GraphQL,
@@ -23,7 +25,8 @@ def graph_ql_db(mock_client: Mock):
         db = GraphQL(
             "https://test.endpoint", "test_token"
         )  # NOSONAR - hardcoded token acceptable in tests
-        return db
+        db.client  # trigger lazy construction now, while Client is patched
+    return db
 
 
 def test_db_config_type():
@@ -56,13 +59,28 @@ def test_graph_ql_init(mock_client: Mock):
             "https://test.endpoint", "test_token"
         )  # NOSONAR - hardcoded token acceptable in tests
 
+        assert db.client == mock_client  # client is built lazily, on first access
         mock_transport.assert_called_once_with(
             url="https://test.endpoint", headers={"Authorization": "bearer test_token"}
         )
         mock_client_class.assert_called_once()
-        assert db.client == mock_client
         assert db.module_name == "graph_ql_db"
         assert db.db_name == "GraphQLDb"
+
+
+def test_graph_ql_client_is_per_thread():
+    db = GraphQL(
+        "https://test.endpoint", "test_token"
+    )  # NOSONAR - hardcoded token acceptable in tests
+
+    main_thread_client = db.client
+    other_thread_client: list[Client] = []
+    thread = threading.Thread(target=lambda: other_thread_client.append(db.client))
+    thread.start()
+    thread.join()
+
+    assert db.client is main_thread_client
+    assert other_thread_client[0] is not main_thread_client
 
 
 def test_get_all_posts(graph_ql_db: GraphQL, mock_client: Mock):

--- a/tests/unit_tests/test_db_loading.py
+++ b/tests/unit_tests/test_db_loading.py
@@ -52,7 +52,7 @@ def test_loading_google_json_db_dynamically():
 
     expected_data = {"site_content": {}}
 
-    with patch("google.cloud.storage.Client") as mock_client:
+    with patch("platzky.db.google_json_db.Client") as mock_client:
         client_mock = MagicMock()
         mock_bucket = MagicMock()
         mock_blob = MagicMock()

--- a/tests/unit_tests/test_engine.py
+++ b/tests/unit_tests/test_engine.py
@@ -258,6 +258,34 @@ def test_that_language_menu_has_proper_code(test_app: Engine):
     assert language_menu.get_text() == "en"
 
 
+def _build_dedicated_domain_test_app() -> Engine:
+    config_data = {
+        "APP_NAME": "testingApp",
+        "SECRET_KEY": "secret",  # NOSONAR - hardcoded secret acceptable in tests
+        "USE_WWW": False,
+        "BLOG_PREFIX": "/blog",
+        "LANGUAGES": {
+            "en": {"name": "English", "flag": "gb", "country": "GB", "domain": "en.example.com"},
+            "pl": {"name": "polski", "flag": "pl", "country": "PL", "domain": "pl.example.com"},
+        },
+        "DB": {"TYPE": "json", "DATA": {"site_content": {}}},
+    }
+    config = Config.model_validate(config_data)
+    return create_app_from_config(config)
+
+
+def test_locale_defaults_to_the_language_whose_domain_is_being_visited():
+    # Regression test: a fresh visitor (no session yet) landing directly on a
+    # language's dedicated domain should see that language, not "en" via the
+    # Accept-Language fallback.
+    app = _build_dedicated_domain_test_app()
+    response = app.test_client().get("/", headers={"Host": "pl.example.com"})
+    soup = BeautifulSoup(response.data, "html.parser")
+    language_menu = soup.find("span", class_="language-indicator-text")
+    assert isinstance(language_menu, Tag)
+    assert language_menu.get_text() == "pl"
+
+
 def test_that_language_switch_has_proper_aria_label_text(test_app: Engine):
     response = test_app.test_client().get("/")
     soup = BeautifulSoup(response.data, "html.parser")

--- a/tests/unit_tests/test_engine.py
+++ b/tests/unit_tests/test_engine.py
@@ -286,6 +286,39 @@ def test_locale_defaults_to_the_language_whose_domain_is_being_visited():
     assert language_menu.get_text() == "pl"
 
 
+def test_locale_defaults_to_the_language_whose_domain_includes_a_port():
+    # Regression test: domain configs that include an explicit port (e.g. local/staging
+    # setups like "pl.example.com:5000") must still match the request host's port.
+    config_data = {
+        "APP_NAME": "testingApp",
+        "SECRET_KEY": "secret",  # NOSONAR - hardcoded secret acceptable in tests
+        "USE_WWW": False,
+        "BLOG_PREFIX": "/blog",
+        "LANGUAGES": {
+            "en": {
+                "name": "English",
+                "flag": "gb",
+                "country": "GB",
+                "domain": "en.example.com:5000",
+            },
+            "pl": {
+                "name": "polski",
+                "flag": "pl",
+                "country": "PL",
+                "domain": "pl.example.com:5000",
+            },
+        },
+        "DB": {"TYPE": "json", "DATA": {"site_content": {}}},
+    }
+    config = Config.model_validate(config_data)
+    app = create_app_from_config(config)
+    response = app.test_client().get("/", headers={"Host": "pl.example.com:5000"})
+    soup = BeautifulSoup(response.data, "html.parser")
+    language_menu = soup.find("span", class_="language-indicator-text")
+    assert isinstance(language_menu, Tag)
+    assert language_menu.get_text() == "pl"
+
+
 def test_that_language_switch_has_proper_aria_label_text(test_app: Engine):
     response = test_app.test_client().get("/")
     soup = BeautifulSoup(response.data, "html.parser")

--- a/tests/unit_tests/test_engine.py
+++ b/tests/unit_tests/test_engine.py
@@ -319,6 +319,36 @@ def test_locale_defaults_to_the_language_whose_domain_includes_a_port():
     assert language_menu.get_text() == "pl"
 
 
+def test_locale_does_not_match_domain_on_a_different_port():
+    # Regression test: a domain with an explicit port must not match a request on a
+    # different port, even though the hostname is identical.
+    config_data = {
+        "APP_NAME": "testingApp",
+        "SECRET_KEY": "secret",  # NOSONAR - hardcoded secret acceptable in tests
+        "USE_WWW": False,
+        "BLOG_PREFIX": "/blog",
+        "LANGUAGES": {
+            "en": {"name": "English", "flag": "gb", "country": "GB"},
+            "pl": {
+                "name": "polski",
+                "flag": "pl",
+                "country": "PL",
+                "domain": "pl.example.com:5000",
+            },
+        },
+        "DB": {"TYPE": "json", "DATA": {"site_content": {}}},
+    }
+    config = Config.model_validate(config_data)
+    app = create_app_from_config(config)
+    response = app.test_client().get(
+        "/", headers={"Host": "pl.example.com:6000", "Accept-Language": "en"}
+    )
+    soup = BeautifulSoup(response.data, "html.parser")
+    language_menu = soup.find("span", class_="language-indicator-text")
+    assert isinstance(language_menu, Tag)
+    assert language_menu.get_text() == "en"
+
+
 def test_that_language_switch_has_proper_aria_label_text(test_app: Engine):
     response = test_app.test_client().get("/")
     soup = BeautifulSoup(response.data, "html.parser")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Locale selection now prioritizes the session language, then matches the request host to a configured language (with fallbacks), and stores the result in the session.
* **Bug Fixes**
  * GraphQL now fails clearly when a requested page is not found.
  * Improved GraphQL thread-safety to prevent client sharing across threads.
  * Fixed language dropdown markup and updated a Bootstrap script integrity value.
* **Tests**
  * Added unit tests for per-thread GraphQL clients, missing-page errors, and host-based locale defaults (including ports).
  * Added Cypress e2e coverage for the language switcher.
* **Documentation**
  * Updated `LANGUAGES` and plugin docs, including guidance to use `current_engine()` in request handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->