### PR TITLE
feat: add custom CSS support and hero shortcode

### DIFF
--- a/platzky/blog/blog.py
+++ b/platzky/blog/blog.py
@@ -7,6 +7,7 @@ from typing import TypeVar
 
 from flask import Blueprint, abort, make_response, render_template, request
 from markupsafe import Markup
+from pydantic import ValidationError
 from werkzeug.exceptions import HTTPException
 from werkzeug.wrappers import Response
 
@@ -131,6 +132,15 @@ def create_blog_blueprint(
         """
         try:
             return getter_func(slug)
+        except ValidationError as e:
+            logger.warning(
+                "Content for slug '%s' failed validation and will 404 for visitors. "
+                "If you're an admin: check this content's fields (e.g. css) for "
+                "unexpected data — %s",
+                slug,
+                e,
+            )
+            abort(404)
         except ValueError as e:
             logger.debug("Content not found for slug '%s': %s", slug, e)
             abort(404)
@@ -170,6 +180,7 @@ def create_blog_blueprint(
         return render_template(
             "page.html",
             title=page.title,
+            css=page.css,
             content=content_transformer(page.contentInMarkdown, "page"),
             cover_image=cover_image_url,
         )

--- a/platzky/blog/blog.py
+++ b/platzky/blog/blog.py
@@ -141,13 +141,12 @@ def create_blog_blueprint(
         """
         try:
             return getter_func(slug)
-        except ValidationError as e:
-            logger.error(
+        except ValidationError:
+            logger.exception(
                 "Content for slug '%s' failed validation and will 404 for visitors. "
                 "If you're an admin: check this content's fields (e.g. css) for "
-                "unexpected data — %s",
+                "unexpected data",
                 slug,
-                e,
             )
             abort(404, description=_VALIDATION_FAILED_MARKER)
         except ValueError as e:

--- a/platzky/blog/blog.py
+++ b/platzky/blog/blog.py
@@ -3,9 +3,9 @@
 import logging
 from collections.abc import Callable
 from os.path import dirname
-from typing import TypeVar
+from typing import Final, TypeVar
 
-from flask import Blueprint, abort, make_response, render_template, request
+from flask import Blueprint, abort, make_response, render_template, request, session
 from markupsafe import Markup
 from pydantic import ValidationError
 from werkzeug.exceptions import HTTPException
@@ -20,6 +20,8 @@ from . import comment_form
 _ContentT = TypeVar("_ContentT", Post, Page)
 
 logger = logging.getLogger(__name__)
+
+_VALIDATION_FAILED_MARKER: Final[str] = "content_validation_failed"
 
 
 def create_blog_blueprint(
@@ -59,16 +61,23 @@ def create_blog_blueprint(
         return Markup(text)
 
     @blog.errorhandler(404)
-    def page_not_found(_e: HTTPException) -> tuple[str, int]:
+    def page_not_found(e: HTTPException) -> tuple[str, int]:
         """Handle 404 Not Found errors in blog routes.
 
+        Shows an extra hint on the 404 page, but only to a logged-in admin and
+        only when the 404 was caused by content failing validation (e.g. a
+        css field rejected for a `</style` breakout attempt) rather than the
+        content genuinely not existing — regular visitors always see the
+        plain 404 so the failure reason isn't exposed publicly.
+
         Args:
-            _e: HTTPException object containing error details (unused)
+            e: HTTPException object containing error details
 
         Returns:
             Tuple of rendered 404 template and HTTP 404 status code
         """
-        return render_template("404.html", title="404"), 404
+        show_admin_hint = e.description == _VALIDATION_FAILED_MARKER and bool(session.get("user"))
+        return render_template("404.html", title="404", admin_hint=show_admin_hint), 404
 
     @blog.route("/", methods=["GET"])
     def all_posts() -> str:
@@ -133,14 +142,14 @@ def create_blog_blueprint(
         try:
             return getter_func(slug)
         except ValidationError as e:
-            logger.warning(
+            logger.error(
                 "Content for slug '%s' failed validation and will 404 for visitors. "
                 "If you're an admin: check this content's fields (e.g. css) for "
                 "unexpected data — %s",
                 slug,
                 e,
             )
-            abort(404)
+            abort(404, description=_VALIDATION_FAILED_MARKER)
         except ValueError as e:
             logger.debug("Content not found for slug '%s': %s", slug, e)
             abort(404)

--- a/platzky/blog/blog.py
+++ b/platzky/blog/blog.py
@@ -3,11 +3,10 @@
 import logging
 from collections.abc import Callable
 from os.path import dirname
-from typing import Final, TypeVar
+from typing import TypeVar
 
-from flask import Blueprint, abort, make_response, render_template, request, session
+from flask import Blueprint, abort, make_response, render_template, request
 from markupsafe import Markup
-from pydantic import ValidationError
 from werkzeug.exceptions import HTTPException
 from werkzeug.wrappers import Response
 
@@ -20,8 +19,6 @@ from . import comment_form
 _ContentT = TypeVar("_ContentT", Post, Page)
 
 logger = logging.getLogger(__name__)
-
-_VALIDATION_FAILED_MARKER: Final[str] = "content_validation_failed"
 
 
 def create_blog_blueprint(
@@ -61,23 +58,16 @@ def create_blog_blueprint(
         return Markup(text)
 
     @blog.errorhandler(404)
-    def page_not_found(e: HTTPException) -> tuple[str, int]:
+    def page_not_found(_e: HTTPException) -> tuple[str, int]:
         """Handle 404 Not Found errors in blog routes.
 
-        Shows an extra hint on the 404 page, but only to a logged-in admin and
-        only when the 404 was caused by content failing validation (e.g. a
-        css field rejected for a `</style` breakout attempt) rather than the
-        content genuinely not existing — regular visitors always see the
-        plain 404 so the failure reason isn't exposed publicly.
-
         Args:
-            e: HTTPException object containing error details
+            _e: HTTPException object containing error details (unused)
 
         Returns:
             Tuple of rendered 404 template and HTTP 404 status code
         """
-        show_admin_hint = e.description == _VALIDATION_FAILED_MARKER and bool(session.get("user"))
-        return render_template("404.html", title="404", admin_hint=show_admin_hint), 404
+        return render_template("404.html", title="404"), 404
 
     @blog.route("/", methods=["GET"])
     def all_posts() -> str:
@@ -141,14 +131,6 @@ def create_blog_blueprint(
         """
         try:
             return getter_func(slug)
-        except ValidationError:
-            logger.exception(
-                "Content for slug '%s' failed validation and will 404 for visitors. "
-                "If you're an admin: check this content's fields (e.g. css) for "
-                "unexpected data",
-                slug,
-            )
-            abort(404, description=_VALIDATION_FAILED_MARKER)
         except ValueError as e:
             logger.debug("Content not found for slug '%s': %s", slug, e)
             abort(404)

--- a/platzky/db/db.py
+++ b/platzky/db/db.py
@@ -147,12 +147,16 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def get_home_page_path(self) -> str | None:
+    def get_home_page_path(self, locale: str) -> str | None:
         """Retrieve the site-relative path to render as the site's homepage.
+
+        Args:
+            locale: Language code (e.g., 'en', 'pl') of the current request.
 
         Returns:
             A path such as "/blog/page/about" or "/blog/some-post", resolved
-            against the app's own routes. None if no homepage override is configured.
+            against the app's own routes. None if no homepage override is configured
+            for this locale (or globally).
         """
         pass
 

--- a/platzky/db/graph_ql_db.py
+++ b/platzky/db/graph_ql_db.py
@@ -444,23 +444,30 @@ class GraphQL(DB):
 
         return self.client.execute(favicon)["favicons"][0]["favicon"]["url"]
 
-    def get_home_page_path(self) -> str | None:
+    def get_home_page_path(self, locale: str) -> str | None:
         """Retrieve the site-relative path configured as the site's homepage.
 
+        Each language has its own ``applicationSetups`` entry in the CMS, so the
+        homepage path is looked up for the current locale's entry directly.
+
+        Args:
+            locale: Language code (e.g., 'en', 'pl') of the current request.
+
         Returns:
-            Homepage path, or None if no homepage override is configured.
+            Homepage path, or None if no homepage override is configured for
+            this locale.
         """
         home_page_path_query = gql("""
-            query MyQuery {
-              applicationSetups(stage: PUBLISHED) {
+            query MyQuery($lang: Lang!) {
+              applicationSetups(where: {language: $lang}, stage: PUBLISHED) {
                 homePagePath
               }
             }
             """)
         try:
-            return self.client.execute(home_page_path_query)["applicationSetups"][0].get(
-                "homePagePath"
-            )
+            return self.client.execute(home_page_path_query, variable_values={"lang": locale})[
+                "applicationSetups"
+            ][0].get("homePagePath")
         except IndexError:
             return None
 

--- a/platzky/db/graph_ql_db.py
+++ b/platzky/db/graph_ql_db.py
@@ -82,6 +82,7 @@ def _standardize_post(post: dict[str, Any]) -> dict[str, Any]:
             "url": (post.get("coverImage") or {}).get("image", {}).get("url", ""),
         },
         "date": post["date"],
+        "css": post.get("css") or "",
     }
 
 
@@ -110,6 +111,7 @@ def _standardize_page(page: dict[str, Any]) -> dict[str, Any]:
             "url": (page.get("coverImage") or {}).get("url", ""),
         },
         "date": page.get("date"),
+        "css": page.get("css") or "",
     }
 
 
@@ -265,6 +267,7 @@ class GraphQL(DB):
                 }
                 excerpt
                 tags
+                css
                 coverImage {
                   alternateText
                   image {
@@ -302,6 +305,7 @@ class GraphQL(DB):
                 slug
                 title
                 contentInMarkdown
+                css
                 coverImage
                 {
                     url
@@ -472,12 +476,48 @@ class GraphQL(DB):
             return None
 
     def get_primary_color(self) -> str:
-        """Return the primary brand colour."""
-        return "white"  # Default color as string
+        """Retrieve the primary brand colour configured in the CMS.
+
+        Returns:
+            Primary colour value, or "white" if not configured.
+        """
+        primary_color_query = gql("""
+            query MyQuery {
+              applicationSetups(stage: PUBLISHED) {
+                primaryColor
+              }
+            }
+            """)
+        try:
+            return (
+                self.client.execute(primary_color_query)["applicationSetups"][0].get("primaryColor")
+                or "white"
+            )
+        except IndexError:
+            return "white"
 
     def get_secondary_color(self) -> str:
-        """Return the secondary brand colour."""
-        return "navy"  # Default color as string
+        """Retrieve the secondary brand colour configured in the CMS.
+
+        Returns:
+            Secondary colour value, or "navy" if not configured.
+        """
+        secondary_color_query = gql("""
+            query MyQuery {
+              applicationSetups(stage: PUBLISHED) {
+                secondaryColor
+              }
+            }
+            """)
+        try:
+            return (
+                self.client.execute(secondary_color_query)["applicationSetups"][0].get(
+                    "secondaryColor"
+                )
+                or "navy"
+            )
+        except IndexError:
+            return "navy"
 
     def get_plugins_data(self) -> dict[str, PluginConfigBase]:
         """Retrieve configuration data for all plugins.

--- a/platzky/db/graph_ql_db.py
+++ b/platzky/db/graph_ql_db.py
@@ -478,20 +478,23 @@ class GraphQL(DB):
     def get_primary_color(self) -> str:
         """Retrieve the primary brand colour configured in the CMS.
 
+        Queries the global ``themes`` singleton rather than ``applicationSetups``,
+        since brand colours are site-wide and not language-specific (unlike
+        ``applicationSetups``, which holds one entry per language).
+
         Returns:
             Primary colour value, or "white" if not configured.
         """
         primary_color_query = gql("""
             query MyQuery {
-              applicationSetups(stage: PUBLISHED) {
+              themes(stage: PUBLISHED) {
                 primaryColor
               }
             }
             """)
         try:
             return (
-                self.client.execute(primary_color_query)["applicationSetups"][0].get("primaryColor")
-                or "white"
+                self.client.execute(primary_color_query)["themes"][0].get("primaryColor") or "white"
             )
         except IndexError:
             return "white"
@@ -499,21 +502,23 @@ class GraphQL(DB):
     def get_secondary_color(self) -> str:
         """Retrieve the secondary brand colour configured in the CMS.
 
+        Queries the global ``themes`` singleton rather than ``applicationSetups``,
+        since brand colours are site-wide and not language-specific (unlike
+        ``applicationSetups``, which holds one entry per language).
+
         Returns:
             Secondary colour value, or "navy" if not configured.
         """
         secondary_color_query = gql("""
             query MyQuery {
-              applicationSetups(stage: PUBLISHED) {
+              themes(stage: PUBLISHED) {
                 secondaryColor
               }
             }
             """)
         try:
             return (
-                self.client.execute(secondary_color_query)["applicationSetups"][0].get(
-                    "secondaryColor"
-                )
+                self.client.execute(secondary_color_query)["themes"][0].get("secondaryColor")
                 or "navy"
             )
         except IndexError:

--- a/platzky/db/json_db.py
+++ b/platzky/db/json_db.py
@@ -200,13 +200,23 @@ class Json(DB):
         """
         return self._get_site_content().get("secondary_color", "navy")
 
-    def get_home_page_path(self) -> str | None:
+    def get_home_page_path(self, locale: str) -> str | None:
         """Retrieve the site-relative path configured as the site's homepage.
+
+        ``home_page_path`` may be a single string (applies to every locale) or a
+        dict mapping locale codes to paths, with an optional "default" key used
+        when the current locale has no entry of its own.
+
+        Args:
+            locale: Language code (e.g., 'en', 'pl') of the current request.
 
         Returns:
             Homepage path, or None if no homepage override is configured.
         """
-        return self._get_site_content().get("home_page_path")
+        home_page_path = self._get_site_content().get("home_page_path")
+        if isinstance(home_page_path, dict):
+            return home_page_path.get(locale) or home_page_path.get("default")
+        return home_page_path
 
     def add_comment(self, author_name: str, comment: str, post_slug: str) -> None:
         """Add a new comment to a post.

--- a/platzky/db/json_db.py
+++ b/platzky/db/json_db.py
@@ -215,7 +215,7 @@ class Json(DB):
         """
         home_page_path = self._get_site_content().get("home_page_path")
         if isinstance(home_page_path, dict):
-            return home_page_path.get(locale) or home_page_path.get("default")
+            return home_page_path.get(locale, home_page_path.get("default"))
         return home_page_path
 
     def add_comment(self, author_name: str, comment: str, post_slug: str) -> None:

--- a/platzky/db/mongodb_db.py
+++ b/platzky/db/mongodb_db.py
@@ -230,14 +230,24 @@ class MongoDB(DB):
         site_config = self._get_site_config()
         return site_config.get("font", "") if site_config else ""
 
-    def get_home_page_path(self) -> str | None:
+    def get_home_page_path(self, locale: str) -> str | None:
         """Retrieve the site-relative path configured as the site's homepage.
+
+        ``home_page_path`` may be a single string (applies to every locale) or a
+        dict mapping locale codes to paths, with an optional "default" key used
+        when the current locale has no entry of its own.
+
+        Args:
+            locale: Language code (e.g., 'en', 'pl') of the current request.
 
         Returns:
             Homepage path, or None if no homepage override is configured.
         """
         site_config = self._get_site_config()
-        return site_config.get("home_page_path") if site_config else None
+        home_page_path = site_config.get("home_page_path") if site_config else None
+        if isinstance(home_page_path, dict):
+            return home_page_path.get(locale) or home_page_path.get("default")
+        return home_page_path
 
     def health_check(self) -> None:
         """Perform a health check on the MongoDB database.

--- a/platzky/db/mongodb_db.py
+++ b/platzky/db/mongodb_db.py
@@ -246,7 +246,7 @@ class MongoDB(DB):
         site_config = self._get_site_config()
         home_page_path = site_config.get("home_page_path") if site_config else None
         if isinstance(home_page_path, dict):
-            return home_page_path.get(locale) or home_page_path.get("default")
+            return home_page_path.get(locale, home_page_path.get("default"))
         return home_page_path
 
     def health_check(self) -> None:

--- a/platzky/models.py
+++ b/platzky/models.py
@@ -2,6 +2,7 @@
 
 import datetime
 import functools
+import re
 from typing import Annotated
 
 import humanize
@@ -16,6 +17,27 @@ def _ensure_utc(v: datetime.datetime) -> datetime.datetime:
 
 
 DateTimeField = Annotated[datetime.datetime, AfterValidator(_ensure_utc)]
+
+_STYLE_CLOSE_RE = re.compile(r"</\s*style\b", re.IGNORECASE)
+
+
+def _reject_style_breakout(css: str) -> str:
+    """Reject CSS containing `</style`, which could break out of its wrapping tag.
+
+    Content inside a <style> element is HTML "raw text" — browsers don't parse
+    markup there except the literal closing tag. The `css` field is rendered with
+    the `safe` filter (to preserve real CSS like `.a > .b`), so this guards the one
+    sequence that could let stored content inject arbitrary HTML/script via the
+    page's <head>. Raising here (rather than silently stripping it) means content
+    with this pattern fails to load — see blog.py's handling of ValidationError for
+    why that's preferable to rendering mutated content unexpectedly.
+    """
+    if _STYLE_CLOSE_RE.search(css):
+        raise ValueError("css must not contain a '</style' sequence")
+    return css
+
+
+CssField = Annotated[str, AfterValidator(_reject_style_breakout)]
 
 
 class CmsModule(BaseModel):
@@ -101,6 +123,9 @@ class Post(BaseModel):
         comments: Optional list of comments on this post
         tags: Optional list of tags for categorization
         date: Optional datetime when the post was published (timezone-aware recommended)
+        css: Optional CSS rendered inline in this post/page's own <head>, scoped to
+            this content only — can target the masthead, hero blocks, paragraphs,
+            or anything else on the page
     """
 
     author: str
@@ -113,6 +138,7 @@ class Post(BaseModel):
     comments: list[Comment] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
     date: DateTimeField | None = None
+    css: CssField = ""
 
     def __lt__(self, other: object) -> bool:
         """Compare posts by date for sorting.

--- a/platzky/platzky.py
+++ b/platzky/platzky.py
@@ -173,10 +173,11 @@ def _change_language_response(config: Config, lang: str) -> Response:
 def _home_page_response(app: Engine, config: Config) -> ResponseReturnValue:
     """Render the configured homepage, falling back to the blog index.
 
-    Resolves db.get_home_page_path() through the app's own URL map, so it
-    can point at a page, a post, or any other registered route. Falls back
-    to the blog index if no homepage is configured, or if the configured
-    path resolves back to this same route (which would otherwise recurse).
+    Resolves db.get_home_page_path() for the current request's locale through
+    the app's own URL map, so it can point at a page, a post, or any other
+    registered route. Falls back to the blog index if no homepage is
+    configured for that locale, or if the configured path resolves back to
+    this same route (which would otherwise recurse).
 
     Args:
         app: Platzky Engine instance
@@ -185,7 +186,7 @@ def _home_page_response(app: Engine, config: Config) -> ResponseReturnValue:
     Returns:
         Rendered HTML of the resolved destination, or the 404 page.
     """
-    configured_home = app.db.get_home_page_path()
+    configured_home = app.db.get_home_page_path(app.get_locale())
     target_path = (
         configured_home
         if isinstance(configured_home, str) and configured_home not in {"", "/"}

--- a/platzky/shortcodes/builtins.py
+++ b/platzky/shortcodes/builtins.py
@@ -1,17 +1,19 @@
 """Built-in shortcode handlers for images and links."""
 
 from platzky.shortcodes import Shortcode
+from platzky.shortcodes.hero import hero_shortcode
 from platzky.shortcodes.image import image_shortcode
 from platzky.shortcodes.link import link_shortcode
 
 
 def get_builtin_shortcodes() -> dict[str, Shortcode]:
-    """Return built-in shortcode descriptors for images and links.
+    """Return built-in shortcode descriptors for images, links, and hero blocks.
 
     Returns:
-        Map of tag name to Shortcode for the built-in image and link tags.
+        Map of tag name to Shortcode for the built-in image, link, and hero tags.
     """
     return {
         image_shortcode.name: image_shortcode,
         link_shortcode.name: link_shortcode,
+        hero_shortcode.name: hero_shortcode,
     }

--- a/platzky/shortcodes/hero.py
+++ b/platzky/shortcodes/hero.py
@@ -1,0 +1,26 @@
+"""Built-in hero shortcode."""
+
+from platzky.shortcodes.shortcode import Shortcode, ShortcodeAttrs
+
+
+class HeroShortcode(Shortcode):
+    """Wrap content in a header block, independent of the page/post masthead."""
+
+    name = "hero"
+    description = "Wrap content in a hero/header block, anywhere in the body."
+    example = "[hero]<h1>Headline</h1><p>Subheading text</p>[/hero]"
+
+    def render(self, attrs: ShortcodeAttrs, content: str) -> str:  # noqa: ARG002
+        """Wrap the inner content in a ``.hero`` container, used as-is.
+
+        Args:
+            attrs: Unused — hero currently takes no attributes.
+            content: Raw inner HTML/text between the tags.
+
+        Returns:
+            The content wrapped in a ``<div class="hero">``.
+        """
+        return f'<div class="hero">{content}</div>'
+
+
+hero_shortcode = HeroShortcode()

--- a/platzky/static/blog.css
+++ b/platzky/static/blog.css
@@ -401,3 +401,14 @@ footer .copyright {
 {
     max-width: 100%;
 }
+
+/* Default look for the [hero] shortcode; override by targeting .hero
+   in a site/plugin stylesheet loaded after this one. */
+.hero {
+    padding: 3rem 1.5rem;
+    margin-bottom: 2rem;
+    text-align: center;
+    background: #f7f8fa;
+    border-radius: 8px;
+    font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}

--- a/platzky/templates/404.html
+++ b/platzky/templates/404.html
@@ -22,9 +22,6 @@
     <div class="row">
       <div class="col-lg-8 col-md-10 mx-auto post-content text-center">
         <p>{{ _("The page you were looking for may have been moved, renamed, or never existed.") }}</p>
-        {% if admin_hint %}
-        <p class="text-danger">{{ _("Admin notice: this content failed validation (e.g. its css field) rather than being missing — check the server logs and fix the content.") }}</p>
-        {% endif %}
         <a href="/" class="btn btn-primary">{{ _("Back to homepage") }}</a>
       </div>
     </div>

--- a/platzky/templates/404.html
+++ b/platzky/templates/404.html
@@ -22,6 +22,9 @@
     <div class="row">
       <div class="col-lg-8 col-md-10 mx-auto post-content text-center">
         <p>{{ _("The page you were looking for may have been moved, renamed, or never existed.") }}</p>
+        {% if admin_hint %}
+        <p class="text-danger">{{ _("Admin notice: this content failed validation (e.g. its css field) rather than being missing — check the server logs and fix the content.") }}</p>
+        {% endif %}
         <a href="/" class="btn btn-primary">{{ _("Back to homepage") }}</a>
       </div>
     </div>

--- a/platzky/templates/page.html
+++ b/platzky/templates/page.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block head_title %}{{ title }} – {{ app_name }}{% endblock %}
+{% block head_meta %}{% if css %}<style>{{ css | safe }}</style>{% endif %}{% endblock %}
 
 {% block content %}
 <header class="masthead" style="background-image: url({{cover_image}})">

--- a/platzky/templates/post.html
+++ b/platzky/templates/post.html
@@ -13,6 +13,7 @@
 {% elif logo_url %}
 <meta name="twitter:image" content="{{ logo_url }}">
 {% endif %}{% endblock %}
+{% block head_meta %}{% if post.css %}<style>{{ post.css | safe }}</style>{% endif %}{% endblock %}
 
 {% block content %}
 <header class="masthead" style="background-image: url({{post.coverImage.url}})">

--- a/tests/e2e_tests/cypress/e2e/simple_test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/simple_test.cy.js
@@ -55,6 +55,23 @@ describe('Blog test', () => {
     cy.contains('page content')
   })
 
+  it('404s a page whose css tries to break out of its <style> tag', () => {
+    // The test data has a page whose css field is
+    // "</style><script>alert('xss')</script><style>" — the trailing <style>
+    // is part of the attack: it would make the page look visually unchanged
+    // even if the breakout worked. Model validation rejects this css outright,
+    // so the page 404s rather than rendering a live <script> tag.
+    const url = '/blog/page/style-breakout'
+    cy.request({url: url, failOnStatusCode: false})
+      .then(resp => expect(resp.status).to.eq(404))
+
+    cy.visit(url, {failOnStatusCode: false})
+    cy.contains("This page doesn't exist")
+    cy.on('window:alert', () => {
+      throw new Error('script from css breakout executed')
+    })
+  })
+
 // TODO add tests:
 //   - post and page without image
 //

--- a/tests/e2e_tests/cypress/e2e/simple_test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/simple_test.cy.js
@@ -62,14 +62,15 @@ describe('Blog test', () => {
     // even if the breakout worked. Model validation rejects this css outright,
     // so the page 404s rather than rendering a live <script> tag.
     const url = '/blog/page/style-breakout'
+    cy.on('window:alert', () => {
+      throw new Error('script from css breakout executed')
+    })
+
     cy.request({url: url, failOnStatusCode: false})
       .then(resp => expect(resp.status).to.eq(404))
 
     cy.visit(url, {failOnStatusCode: false})
     cy.contains("This page doesn't exist")
-    cy.on('window:alert', () => {
-      throw new Error('script from css breakout executed')
-    })
   })
 
 // TODO add tests:

--- a/tests/e2e_tests/e2e_test_data.json
+++ b/tests/e2e_tests/e2e_test_data.json
@@ -142,6 +142,14 @@
           "alternateText": "alternate text",
           "url": "https://media.graphcms.com/XvmCDUjYTIq4c9wOIseo"
         }
+      },
+      {
+        "title": "style breakout page",
+        "author": "autor",
+        "slug": "style-breakout",
+        "contentInMarkdown": "page content",
+        "excerpt": "page excerpt",
+        "css": "</style><script>alert('xss')</script><style>"
       }
     ],
     "menu_items": {

--- a/tests/unit_tests/db/test_graph_ql_db.py
+++ b/tests/unit_tests/db/test_graph_ql_db.py
@@ -305,7 +305,7 @@ def test_get_home_page_path(graph_ql_db: GraphQL, mock_client: Mock):
     mock_response = {"applicationSetups": [{"homePagePath": "/blog/page/about"}]}
     mock_client.execute.return_value = mock_response
 
-    assert graph_ql_db.get_home_page_path() == "/blog/page/about"
+    assert graph_ql_db.get_home_page_path("en") == "/blog/page/about"
     mock_client.execute.assert_called_once()
 
 
@@ -313,13 +313,13 @@ def test_get_home_page_path_missing(graph_ql_db: GraphQL, mock_client: Mock):
     mock_response = {"applicationSetups": [{}]}
     mock_client.execute.return_value = mock_response
 
-    assert graph_ql_db.get_home_page_path() is None
+    assert graph_ql_db.get_home_page_path("en") is None
 
 
 def test_get_home_page_path_no_application_setups(graph_ql_db: GraphQL, mock_client: Mock):
     mock_client.execute.return_value = {"applicationSetups": []}
 
-    assert graph_ql_db.get_home_page_path() is None
+    assert graph_ql_db.get_home_page_path("en") is None
 
 
 def test_get_primary_color(graph_ql_db: GraphQL):

--- a/tests/unit_tests/db/test_graph_ql_db.py
+++ b/tests/unit_tests/db/test_graph_ql_db.py
@@ -369,7 +369,7 @@ def test_get_home_page_path_no_application_setups(graph_ql_db: GraphQL, mock_cli
 
 
 def test_get_primary_color(graph_ql_db: GraphQL, mock_client: Mock):
-    mock_client.execute.return_value = {"applicationSetups": [{"primaryColor": "#0085A1"}]}
+    mock_client.execute.return_value = {"themes": [{"primaryColor": "#0085A1"}]}
 
     color = graph_ql_db.get_primary_color()
 
@@ -378,19 +378,19 @@ def test_get_primary_color(graph_ql_db: GraphQL, mock_client: Mock):
 
 
 def test_get_primary_color_missing(graph_ql_db: GraphQL, mock_client: Mock):
-    mock_client.execute.return_value = {"applicationSetups": [{}]}
+    mock_client.execute.return_value = {"themes": [{}]}
 
     assert graph_ql_db.get_primary_color() == "white"
 
 
-def test_get_primary_color_no_application_setups(graph_ql_db: GraphQL, mock_client: Mock):
-    mock_client.execute.return_value = {"applicationSetups": []}
+def test_get_primary_color_no_themes(graph_ql_db: GraphQL, mock_client: Mock):
+    mock_client.execute.return_value = {"themes": []}
 
     assert graph_ql_db.get_primary_color() == "white"
 
 
 def test_get_secondary_color(graph_ql_db: GraphQL, mock_client: Mock):
-    mock_client.execute.return_value = {"applicationSetups": [{"secondaryColor": "#006073"}]}
+    mock_client.execute.return_value = {"themes": [{"secondaryColor": "#006073"}]}
 
     color = graph_ql_db.get_secondary_color()
 
@@ -399,13 +399,13 @@ def test_get_secondary_color(graph_ql_db: GraphQL, mock_client: Mock):
 
 
 def test_get_secondary_color_missing(graph_ql_db: GraphQL, mock_client: Mock):
-    mock_client.execute.return_value = {"applicationSetups": [{}]}
+    mock_client.execute.return_value = {"themes": [{}]}
 
     assert graph_ql_db.get_secondary_color() == "navy"
 
 
-def test_get_secondary_color_no_application_setups(graph_ql_db: GraphQL, mock_client: Mock):
-    mock_client.execute.return_value = {"applicationSetups": []}
+def test_get_secondary_color_no_themes(graph_ql_db: GraphQL, mock_client: Mock):
+    mock_client.execute.return_value = {"themes": []}
 
     assert graph_ql_db.get_secondary_color() == "navy"
 

--- a/tests/unit_tests/db/test_graph_ql_db.py
+++ b/tests/unit_tests/db/test_graph_ql_db.py
@@ -159,6 +159,7 @@ def test_get_post(graph_ql_db: GraphQL, mock_client: Mock):
             "comments": [
                 {"author": "Jane Doe", "comment": "Great post!", "createdAt": "2023-01-01"}
             ],
+            "css": ".masthead { background: teal; }",
         }
     }
     mock_client.execute.return_value = mock_response
@@ -168,10 +169,58 @@ def test_get_post(graph_ql_db: GraphQL, mock_client: Mock):
     assert isinstance(post, Post)
     assert post.title == "Test Post"
     assert post.slug == "test-post"
+    assert post.css == ".masthead { background: teal; }"
     mock_client.execute.assert_called_once()
 
 
+def test_get_post_without_css(graph_ql_db: GraphQL, mock_client: Mock):
+    mock_response = {
+        "post": {
+            "date": "2023-01-01",
+            "language": "en",
+            "title": "Test Post",
+            "slug": "test-post",
+            "author": {"name": "John Doe"},
+            "contentInRichText": {"markdown": "Test content", "html": "<p>Test content</p>"},
+            "excerpt": "Test excerpt",
+            "tags": ["test", "example"],
+            "coverImage": {
+                "alternateText": "Alt text",
+                "image": {"url": "https://example.com/image.jpg"},
+            },
+            "comments": [],
+            "css": None,
+        }
+    }
+    mock_client.execute.return_value = mock_response
+
+    post = graph_ql_db.get_post("test-post")
+
+    assert post.css == ""
+
+
 def test_get_page(graph_ql_db: GraphQL, mock_client: Mock):
+    mock_response = {
+        "page": {
+            "slug": "about",
+            "title": "About",
+            "contentInMarkdown": "About page content",
+            "coverImage": {"url": "https://example.com/image.jpg"},
+            "css": ".masthead { background: teal; }",
+        }
+    }
+    mock_client.execute.return_value = mock_response
+
+    page = graph_ql_db.get_page("about")
+
+    assert isinstance(page, Post)  # Page is an alias for Post
+    assert page.title == "About"
+    assert page.contentInMarkdown == "About page content"
+    assert page.css == ".masthead { background: teal; }"
+    mock_client.execute.assert_called_once()
+
+
+def test_get_page_without_css(graph_ql_db: GraphQL, mock_client: Mock):
     mock_response = {
         "page": {
             "slug": "about",
@@ -184,10 +233,7 @@ def test_get_page(graph_ql_db: GraphQL, mock_client: Mock):
 
     page = graph_ql_db.get_page("about")
 
-    assert isinstance(page, Post)  # Page is an alias for Post
-    assert page.title == "About"
-    assert page.contentInMarkdown == "About page content"
-    mock_client.execute.assert_called_once()
+    assert page.css == ""
 
 
 def test_get_page_not_found(graph_ql_db: GraphQL, mock_client: Mock):
@@ -322,14 +368,46 @@ def test_get_home_page_path_no_application_setups(graph_ql_db: GraphQL, mock_cli
     assert graph_ql_db.get_home_page_path("en") is None
 
 
-def test_get_primary_color(graph_ql_db: GraphQL):
+def test_get_primary_color(graph_ql_db: GraphQL, mock_client: Mock):
+    mock_client.execute.return_value = {"applicationSetups": [{"primaryColor": "#0085A1"}]}
+
     color = graph_ql_db.get_primary_color()
-    assert color == "white"
+
+    assert color == "#0085A1"
+    mock_client.execute.assert_called_once()
 
 
-def test_get_secondary_color(graph_ql_db: GraphQL):
+def test_get_primary_color_missing(graph_ql_db: GraphQL, mock_client: Mock):
+    mock_client.execute.return_value = {"applicationSetups": [{}]}
+
+    assert graph_ql_db.get_primary_color() == "white"
+
+
+def test_get_primary_color_no_application_setups(graph_ql_db: GraphQL, mock_client: Mock):
+    mock_client.execute.return_value = {"applicationSetups": []}
+
+    assert graph_ql_db.get_primary_color() == "white"
+
+
+def test_get_secondary_color(graph_ql_db: GraphQL, mock_client: Mock):
+    mock_client.execute.return_value = {"applicationSetups": [{"secondaryColor": "#006073"}]}
+
     color = graph_ql_db.get_secondary_color()
-    assert color == "navy"
+
+    assert color == "#006073"
+    mock_client.execute.assert_called_once()
+
+
+def test_get_secondary_color_missing(graph_ql_db: GraphQL, mock_client: Mock):
+    mock_client.execute.return_value = {"applicationSetups": [{}]}
+
+    assert graph_ql_db.get_secondary_color() == "navy"
+
+
+def test_get_secondary_color_no_application_setups(graph_ql_db: GraphQL, mock_client: Mock):
+    mock_client.execute.return_value = {"applicationSetups": []}
+
+    assert graph_ql_db.get_secondary_color() == "navy"
 
 
 def test_get_plugins_data(graph_ql_db: GraphQL, mock_client: Mock):

--- a/tests/unit_tests/db/test_json_db.py
+++ b/tests/unit_tests/db/test_json_db.py
@@ -247,11 +247,22 @@ class TestJsonDbSiteSettings:
         assert db_minimal.get_secondary_color() == "navy"
 
     def test_get_home_page_path_default(self, db_minimal: Json):
-        assert db_minimal.get_home_page_path() is None
+        assert db_minimal.get_home_page_path("en") is None
 
     def test_get_home_page_path(self):
         db = Json({"site_content": {"home_page_path": "/blog/page/about"}})
-        assert db.get_home_page_path() == "/blog/page/about"
+        assert db.get_home_page_path("en") == "/blog/page/about"
+
+    def test_get_home_page_path_per_locale(self):
+        db = Json(
+            {"site_content": {"home_page_path": {"default": "/blog/", "pl": "/blog/page/o-nas"}}}
+        )
+        assert db.get_home_page_path("pl") == "/blog/page/o-nas"
+        assert db.get_home_page_path("en") == "/blog/"
+
+    def test_get_home_page_path_per_locale_no_default(self):
+        db = Json({"site_content": {"home_page_path": {"pl": "/blog/page/o-nas"}}})
+        assert db.get_home_page_path("en") is None
 
 
 class TestJsonDbComments:

--- a/tests/unit_tests/db/test_json_db.py
+++ b/tests/unit_tests/db/test_json_db.py
@@ -264,6 +264,11 @@ class TestJsonDbSiteSettings:
         db = Json({"site_content": {"home_page_path": {"pl": "/blog/page/o-nas"}}})
         assert db.get_home_page_path("en") is None
 
+    def test_get_home_page_path_present_but_empty_string_is_not_swapped_for_default(self):
+        """Only an absent key falls back to "default" — a present key returns its value as-is."""
+        db = Json({"site_content": {"home_page_path": {"default": "/blog/", "pl": ""}}})
+        assert db.get_home_page_path("pl") == ""
+
 
 class TestJsonDbComments:
     @pytest.fixture

--- a/tests/unit_tests/db/test_mongodb_db.py
+++ b/tests/unit_tests/db/test_mongodb_db.py
@@ -337,6 +337,16 @@ class TestMongoDB:
         }
         assert db.get_home_page_path("en") is None
 
+    def test_get_home_page_path_present_but_empty_string_is_not_swapped_for_default(
+        self, db: MongoDB
+    ):
+        """Only an absent key falls back to "default" — a present key returns its value as-is."""
+        cast(Mock, db.site_content.find_one).return_value = {
+            "_id": "config",
+            "home_page_path": {"default": "/blog/", "pl": ""},
+        }
+        assert db.get_home_page_path("pl") == ""
+
     def test_close_connection(self, db: MongoDB):
         db._close_connection()  # type: ignore[reportPrivateUsage] - Testing private method
         cast(Mock, db.client.close).assert_called_once()

--- a/tests/unit_tests/db/test_mongodb_db.py
+++ b/tests/unit_tests/db/test_mongodb_db.py
@@ -316,11 +316,26 @@ class TestMongoDB:
             "_id": "config",
             "home_page_path": "/blog/page/about",
         }
-        assert db.get_home_page_path() == "/blog/page/about"
+        assert db.get_home_page_path("en") == "/blog/page/about"
 
     def test_get_home_page_path_default(self, db: MongoDB):
         cast(Mock, db.site_content.find_one).return_value = None
-        assert db.get_home_page_path() is None
+        assert db.get_home_page_path("en") is None
+
+    def test_get_home_page_path_per_locale(self, db: MongoDB):
+        cast(Mock, db.site_content.find_one).return_value = {
+            "_id": "config",
+            "home_page_path": {"default": "/blog/", "pl": "/blog/page/o-nas"},
+        }
+        assert db.get_home_page_path("pl") == "/blog/page/o-nas"
+        assert db.get_home_page_path("en") == "/blog/"
+
+    def test_get_home_page_path_per_locale_no_default(self, db: MongoDB):
+        cast(Mock, db.site_content.find_one).return_value = {
+            "_id": "config",
+            "home_page_path": {"pl": "/blog/page/o-nas"},
+        }
+        assert db.get_home_page_path("en") is None
 
     def test_close_connection(self, db: MongoDB):
         db._close_connection()  # type: ignore[reportPrivateUsage] - Testing private method

--- a/tests/unit_tests/test_blog.py
+++ b/tests/unit_tests/test_blog.py
@@ -220,35 +220,6 @@ def test_page_with_style_breakout_css_returns_404(test_app: FlaskClient):
     assert response.status_code == 404
 
 
-def test_validation_failure_404_has_no_admin_hint_for_anonymous_visitor(
-    test_app: FlaskClient,
-):
-    _mock_get_page_with_bad_css(test_app)
-    response = test_app.get("/prefix/page/blabla")
-    assert response.status_code == 404
-    assert b"Admin notice" not in response.data
-
-
-def test_validation_failure_404_has_admin_hint_for_logged_in_admin(test_app: FlaskClient):
-    _mock_get_page_with_bad_css(test_app)
-    with test_app.session_transaction() as sess:
-        sess["user"] = {"name": "admin"}
-    response = test_app.get("/prefix/page/blabla")
-    assert response.status_code == 404
-    assert b"Admin notice" in response.data
-
-
-def test_not_found_404_has_no_admin_hint_even_for_logged_in_admin(test_app: FlaskClient):
-    cast(MagicMock, cast(Engine, test_app.application).db.get_page).side_effect = ValueError(
-        "Page not found"
-    )
-    with test_app.session_transaction() as sess:
-        sess["user"] = {"name": "admin"}
-    response = test_app.get("/prefix/page/not-existing-page")
-    assert response.status_code == 404
-    assert b"Admin notice" not in response.data
-
-
 # TODO create those tests
 # def test_post_without_cover_image(test_app: FlaskClient):
 

--- a/tests/unit_tests/test_blog.py
+++ b/tests/unit_tests/test_blog.py
@@ -225,6 +225,7 @@ def test_validation_failure_404_has_no_admin_hint_for_anonymous_visitor(
 ):
     _mock_get_page_with_bad_css(test_app)
     response = test_app.get("/prefix/page/blabla")
+    assert response.status_code == 404
     assert b"Admin notice" not in response.data
 
 
@@ -233,6 +234,7 @@ def test_validation_failure_404_has_admin_hint_for_logged_in_admin(test_app: Fla
     with test_app.session_transaction() as sess:
         sess["user"] = {"name": "admin"}
     response = test_app.get("/prefix/page/blabla")
+    assert response.status_code == 404
     assert b"Admin notice" in response.data
 
 

--- a/tests/unit_tests/test_blog.py
+++ b/tests/unit_tests/test_blog.py
@@ -189,6 +189,33 @@ def test_page_without_cover_image(test_app: FlaskClient):
     assert response.status_code == 200
 
 
+def test_page_renders_css_field(test_app: FlaskClient):
+    page = Post.model_validate({**mocked_post_json, "css": ".masthead { background: teal; }"})
+    cast(MagicMock, cast(Engine, test_app.application).db.get_page).return_value = page
+    response = test_app.get("/prefix/page/blabla")
+    assert b"<style>.masthead { background: teal; }</style>" in response.data
+
+
+def test_post_renders_css_field(test_app: FlaskClient):
+    post = Post.model_validate({**mocked_post_json, "css": ".masthead { background: teal; }"})
+    cast(MagicMock, cast(Engine, test_app.application).db.get_post).return_value = post
+    response = test_app.get("/prefix/slug")
+    assert b"<style>.masthead { background: teal; }</style>" in response.data
+
+
+def test_page_with_style_breakout_css_returns_404(test_app: FlaskClient):
+    def get_page_with_bad_css(_slug: str) -> Post:
+        return Post.model_validate(
+            {**mocked_post_json, "css": "</style><script>alert(1)</script><style>"}
+        )
+
+    cast(MagicMock, cast(Engine, test_app.application).db.get_page).side_effect = (
+        get_page_with_bad_css
+    )
+    response = test_app.get("/prefix/page/blabla")
+    assert response.status_code == 404
+
+
 # TODO create those tests
 # def test_post_without_cover_image(test_app: FlaskClient):
 

--- a/tests/unit_tests/test_blog.py
+++ b/tests/unit_tests/test_blog.py
@@ -203,7 +203,7 @@ def test_post_renders_css_field(test_app: FlaskClient):
     assert b"<style>.masthead { background: teal; }</style>" in response.data
 
 
-def test_page_with_style_breakout_css_returns_404(test_app: FlaskClient):
+def _mock_get_page_with_bad_css(test_app: FlaskClient) -> None:
     def get_page_with_bad_css(_slug: str) -> Post:
         return Post.model_validate(
             {**mocked_post_json, "css": "</style><script>alert(1)</script><style>"}
@@ -212,8 +212,39 @@ def test_page_with_style_breakout_css_returns_404(test_app: FlaskClient):
     cast(MagicMock, cast(Engine, test_app.application).db.get_page).side_effect = (
         get_page_with_bad_css
     )
+
+
+def test_page_with_style_breakout_css_returns_404(test_app: FlaskClient):
+    _mock_get_page_with_bad_css(test_app)
     response = test_app.get("/prefix/page/blabla")
     assert response.status_code == 404
+
+
+def test_validation_failure_404_has_no_admin_hint_for_anonymous_visitor(
+    test_app: FlaskClient,
+):
+    _mock_get_page_with_bad_css(test_app)
+    response = test_app.get("/prefix/page/blabla")
+    assert b"Admin notice" not in response.data
+
+
+def test_validation_failure_404_has_admin_hint_for_logged_in_admin(test_app: FlaskClient):
+    _mock_get_page_with_bad_css(test_app)
+    with test_app.session_transaction() as sess:
+        sess["user"] = {"name": "admin"}
+    response = test_app.get("/prefix/page/blabla")
+    assert b"Admin notice" in response.data
+
+
+def test_not_found_404_has_no_admin_hint_even_for_logged_in_admin(test_app: FlaskClient):
+    cast(MagicMock, cast(Engine, test_app.application).db.get_page).side_effect = ValueError(
+        "Page not found"
+    )
+    with test_app.session_transaction() as sess:
+        sess["user"] = {"name": "admin"}
+    response = test_app.get("/prefix/page/not-existing-page")
+    assert response.status_code == 404
+    assert b"Admin notice" not in response.data
 
 
 # TODO create those tests

--- a/tests/unit_tests/test_engine.py
+++ b/tests/unit_tests/test_engine.py
@@ -106,12 +106,15 @@ def test_www_redirects(use_www: bool):
     assert response.location == expected_redirect
 
 
-def _build_home_page_test_app(site_content: dict[str, Any]):
+def _build_home_page_test_app(
+    site_content: dict[str, Any], languages: dict[str, Any] | None = None
+):
     config_data = {
         "APP_NAME": "testingApp",
         "SECRET_KEY": "secret",  # NOSONAR - hardcoded secret acceptable in tests
         "USE_WWW": False,
         "BLOG_PREFIX": "/blog",
+        "LANGUAGES": languages or {},
         "DB": {"TYPE": "json", "DATA": {"site_content": site_content}},
     }
     config = Config.model_validate(config_data)
@@ -183,6 +186,43 @@ def test_home_page_falls_back_to_blog_index_when_not_configured():
     response = app.test_client().get("/")
     assert response.status_code == 200
     assert b"Latest post" in response.data
+
+
+def test_home_page_resolves_per_locale_path():
+    app = _build_home_page_test_app(
+        {
+            "home_page_path": {"default": "/blog/page/about", "pl": "/blog/page/o-nas"},
+            "pages": [
+                {
+                    "title": "About us",
+                    "slug": "about",
+                    "contentInMarkdown": "Hello there",
+                    "author": "author",
+                    "excerpt": "excerpt",
+                },
+                {
+                    "title": "O nas",
+                    "slug": "o-nas",
+                    "contentInMarkdown": "Witaj",
+                    "author": "author",
+                    "excerpt": "excerpt",
+                },
+            ],
+        },
+        languages={
+            "en": {"name": "English", "flag": "us", "country": "US"},
+            "pl": {"name": "Polski", "flag": "pl", "country": "PL"},
+        },
+    )
+    # Separate clients avoid the language session cookie from one request
+    # leaking into the other and masking the per-locale resolution.
+    default_response = app.test_client().get("/", headers={"Accept-Language": "en"})
+    assert default_response.status_code == 200
+    assert b"Hello there" in default_response.data
+
+    pl_response = app.test_client().get("/", headers={"Accept-Language": "pl"})
+    assert pl_response.status_code == 200
+    assert b"Witaj" in pl_response.data
 
 
 def test_home_page_404s_when_configured_path_does_not_resolve():

--- a/tests/unit_tests/test_models.py
+++ b/tests/unit_tests/test_models.py
@@ -131,3 +131,22 @@ class TestPostWithMinimalFields:
         assert page.comments == []
         assert page.tags == []
         assert page.date is None
+
+
+class TestCssField:
+    def test_default_is_empty(self):
+        post = make_post()
+        assert post.css == ""
+
+    def test_legitimate_css_passes_through_unchanged(self):
+        css = ".masthead { background: teal; } .a > .b { color: red; }"
+        post = make_post(css=css)
+        assert post.css == css
+
+    def test_style_breakout_is_rejected(self):
+        with pytest.raises(ValidationError):
+            make_post(css="</style><script>alert(1)</script><style>")
+
+    def test_style_breakout_is_rejected_case_and_whitespace_insensitive(self):
+        with pytest.raises(ValidationError):
+            make_post(css="</STYLE  ><script>alert(1)</script>")

--- a/tests/unit_tests/test_shortcode_builtins.py
+++ b/tests/unit_tests/test_shortcode_builtins.py
@@ -66,3 +66,13 @@ class TestLinkShortcode:
     def test_data_url_rejected(self) -> None:
         result = _apply('[link url="data:text/html,<h1>x</h1>"]x[/link]')
         assert "<a" not in result
+
+
+class TestHeroShortcode:
+    def test_wraps_content_in_hero_div(self) -> None:
+        result = _apply("[hero]<h1>Headline</h1><p>Subheading text</p>[/hero]")
+        assert result == '<div class="hero"><h1>Headline</h1><p>Subheading text</p></div>'
+
+    def test_plain_text_content(self) -> None:
+        result = _apply("[hero]Just some text[/hero]")
+        assert result == '<div class="hero">Just some text</div>'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Posts and pages now support inline custom CSS, automatically injected into the page header when provided.
  * Homepage path resolution is now locale-aware, with clear fallback behavior when locale-specific overrides are missing.
  * Added the **hero** shortcode to render prominent, styled content blocks.
  * Theme primary/secondary colors are now read from published theme data (with sensible fallbacks).

* **Security Improvements**
  * Custom CSS is validated to prevent style-tag breakout and related script injection.

* **Tests**
  * Added e2e and unit coverage for locale behavior, CSS rendering, and style-breakout rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->