### PR TITLE
feat: add #overlay-root portal target to enable showing elements above whole app

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -257,8 +257,33 @@ inject at the start of ``<body>``. Only sections declared in ``accepted_page_sec
 **and** permitted by ``allowed_page_sections`` in the database config are injected —
 neither side alone controls what gets rendered.
 
-Host-Defined Capabilities
--------------------------
+Frontend Overlays
+-----------------
+
+.. versionadded:: 2.0.0
+
+Platzky's base template contains the page content in ``#main-row``, which
+establishes a stacking context — frontend code rendered inside it (a map, a
+widget) cannot paint above the navbar or above elements portalled to
+``<body>``, regardless of its ``z-index``.
+
+Overlays that must escape this — toasts, dialogs, popovers — should be rendered
+into ``#overlay-root``, a ``position: fixed`` layer that is the first element of
+``<body>`` on every page. It spans the content area horizontally (excluding the
+left panel when one is visible) and the full viewport vertically, and stacks
+above both the content area and Bootstrap/MUI modals. The layer itself ignores
+pointer events; its direct children receive them.
+
+Two CSS conventions apply to children of the layer:
+
+- Position with ``inset-inline: 0`` (or logical equivalents) — the layer already
+  starts at the content area's edge, so no runtime measuring is needed.
+- Avoid sizing a child to the full layer: it spans the viewport vertically, so a
+  full-size child covers the navbar and intercepts its clicks.
+
+The left panel's layout width is also exposed as the ``--left-panel-width``
+custom property (``0px`` when the panel is offcanvas or absent), for frontend
+code that needs to offset against the content area outside the overlay layer.
 
 .. versionadded:: 2.0.0
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -262,33 +262,38 @@ Frontend Overlays
 
 .. versionadded:: 2.0.0
 
-Platzky's base template contains the page content in ``#main-row``, which
-establishes a stacking context — frontend code rendered inside it (a map, a
-widget) cannot paint above the navbar or above elements portalled to
-``<body>``, regardless of its ``z-index``.
+To show a toast, dialog, or popover above the page content, render it into the
+``#overlay-root`` element — present on every page — instead of into your own
+markup. Overlays rendered anywhere else end up below the navbar or below
+modals, regardless of their ``z-index``.
 
-Overlays that must escape this — toasts, dialogs, popovers — should be rendered
-into ``#overlay-root``, a ``position: fixed`` layer that is the first element of
-``<body>`` on every page. It spans the content area horizontally (excluding the
-left panel when one is visible) and the full viewport vertically, and stacks
-above both the content area and Bootstrap/MUI modals. The layer itself ignores
-pointer events; its direct children receive them.
+.. code-block:: javascript
 
-Because the element is first in ``<body>``, scripts injected into the body can
-look it up directly. Scripts injected into ``<head>`` (via ``dynamic_head``)
-execute before ``<body>`` is parsed and must defer the lookup until
-``DOMContentLoaded``.
+    const toast = document.createElement("div");
+    toast.style.cssText = "position: absolute; top: 50%; inset-inline: 0;";
+    document.getElementById("overlay-root").append(toast);
 
-Two CSS conventions apply to children of the layer:
+Position children with ``position: absolute`` and logical insets:
+``inset-inline: 0`` spans exactly the visible content area (the left panel,
+when one is shown, is already excluded), so there is nothing to measure at
+runtime.
 
-- Position with ``inset-inline: 0`` (or logical equivalents) — the layer already
-  starts at the content area's edge, so no runtime measuring is needed.
-- Avoid sizing a child to the full layer: it spans the viewport vertically, so a
+Rules to keep in mind:
+
+- Scripts in ``<body>`` can look the element up directly. Scripts injected into
+  ``<head>`` via ``dynamic_head`` run before ``<body>`` is parsed and must wait
+  for ``DOMContentLoaded``.
+- Don't size a child to the full layer: the layer is viewport-high, so a
   full-size child covers the navbar and intercepts its clicks.
+- Clicks pass through the layer to the page underneath; only your children
+  receive pointer events.
 
-The left panel's layout width is also exposed as the ``--left-panel-width``
-custom property (``0px`` when the panel is offcanvas or absent), for frontend
-code that needs to offset against the content area outside the overlay layer.
+To offset other frontend elements against the content area, use the
+``--left-panel-width`` CSS custom property — the left panel's current layout
+width (``0px`` when it is collapsed to an offcanvas or absent).
+
+Host-Defined Capabilities
+-------------------------
 
 .. versionadded:: 2.0.0
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -273,10 +273,11 @@ modals, regardless of their ``z-index``.
     toast.style.cssText = "position: absolute; top: 50%; inset-inline: 0;";
     document.getElementById("overlay-root").append(toast);
 
-Position children with ``position: absolute`` and logical insets:
-``inset-inline: 0`` spans exactly the visible content area (the left panel,
-when one is shown, is already excluded), so there is nothing to measure at
-runtime.
+The layer spans exactly the visible content area — the left panel, when one is
+shown, is already excluded — so there is nothing to measure at runtime. Both
+``position: absolute`` and ``position: fixed`` children resolve their insets
+against the layer rather than the viewport, so overlay libraries that default
+to ``fixed`` work unmodified.
 
 Rules to keep in mind:
 
@@ -285,12 +286,10 @@ Rules to keep in mind:
   for ``DOMContentLoaded``.
 - Don't size a child to the full layer: the layer is viewport-high, so a
   full-size child covers the navbar and intercepts its clicks.
-- Clicks pass through the layer to the page underneath; only your children
-  receive pointer events.
-
-To offset other frontend elements against the content area, use the
-``--left-panel-width`` CSS custom property — the left panel's current layout
-width (``0px`` when it is collapsed to an offcanvas or absent).
+- Clicks pass through the layer to the page underneath, but each direct child
+  takes them. A child that spans the layer blocks clicks across the whole
+  content area even where it draws nothing, so give it
+  ``pointer-events: none`` and re-enable it on the parts that are visible.
 
 Host-Defined Capabilities
 -------------------------

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -274,6 +274,11 @@ left panel when one is visible) and the full viewport vertically, and stacks
 above both the content area and Bootstrap/MUI modals. The layer itself ignores
 pointer events; its direct children receive them.
 
+Because the element is first in ``<body>``, scripts injected into the body can
+look it up directly. Scripts injected into ``<head>`` (via ``dynamic_head``)
+execute before ``<body>`` is parsed and must defer the lookup until
+``DOMContentLoaded``.
+
 Two CSS conventions apply to children of the layer:
 
 - Position with ``inset-inline: 0`` (or logical equivalents) — the layer already

--- a/platzky/static/styles.css
+++ b/platzky/static/styles.css
@@ -182,9 +182,8 @@ main {
 
   #left-panel {
     position: relative;
-    /* Both needed: they override inline-size/max-width from dynamic_css.html. */
+    /* Overrides the offcanvas sizing (80vw) from dynamic_css.html. */
     inline-size: var(--left-panel-width);
-    max-width: var(--left-panel-width);
     display: flex;
     flex-direction: column;
     max-height: 100%;

--- a/platzky/static/styles.css
+++ b/platzky/static/styles.css
@@ -1,10 +1,3 @@
-/* Layout width of the left panel: 0 while it is an offcanvas overlay (<992px)
-   or absent; set to its real width on body.has-left-panel below. Part of the
-   consumer contract in docs/plugins.rst, "Frontend Overlays". */
-:root {
-  --left-panel-width: 0px;
-}
-
 html {
   height: 100%;
   overflow: hidden;
@@ -37,21 +30,30 @@ body {
 }
 
 /* Portal target for overlays that must escape #main-row's stacking context.
-   Full viewport height because the navbar's height is content-dependent and
-   not expressible here. Consumer contract: docs/plugins.rst, "Frontend
-   Overlays". */
+   Spans the content area: the left panel is excluded whenever it takes up
+   layout width (--left-panel-width, set below), and the fallback covers the
+   viewport-wide case. Full viewport height because the navbar's height is
+   content-dependent and not expressible here. Consumer contract:
+   docs/plugins.rst, "Frontend Overlays". */
 #overlay-root {
   position: fixed;
   top: 0;
   bottom: 0;
-  inset-inline-start: var(--left-panel-width);
+  inset-inline-start: var(--left-panel-width, 0px);
   inset-inline-end: 0;
   /* Above Bootstrap's modal (1055) and MUI's Dialog (1300). */
   z-index: 2000;
   pointer-events: none;
+  /* Containing block for position: fixed children, which would otherwise
+     resolve against the viewport and ignore the insets above. Overlay
+     libraries default to fixed because they assume a portal into <body>. */
+  contain: layout;
 }
 
-/* The layer must not swallow clicks on content under it; children opt back in. */
+/* The layer must not swallow clicks on content under it; children opt back in.
+   A child that spans the layer therefore blocks clicks across the whole content
+   area - such children have to set pointer-events: none on themselves and
+   re-enable it on their visible parts. */
 #overlay-root > * {
   pointer-events: auto;
 }
@@ -172,16 +174,17 @@ main {
 
 @media only screen and (min-width: 992px) {
   /* Above this breakpoint the panel stops being an offcanvas overlay and takes
-     up real width in the layout. */
-  body.has-left-panel {
+     up real width in the layout, which #overlay-root has to skip. Internal to
+     this stylesheet - not part of the documented plugin contract. */
+  body:has(#left-panel) {
     --left-panel-width: 220px;
   }
 
   #left-panel {
     position: relative;
+    /* Both needed: they override inline-size/max-width from dynamic_css.html. */
     inline-size: var(--left-panel-width);
     max-width: var(--left-panel-width);
-    width: var(--left-panel-width);
     display: flex;
     flex-direction: column;
     max-height: 100%;

--- a/platzky/static/styles.css
+++ b/platzky/static/styles.css
@@ -1,6 +1,6 @@
 /* Layout width of the left panel: 0 while it is an offcanvas overlay (<992px)
-   or absent; set to its real width on body.has-left-panel below. Offset against
-   the content area with this instead of measuring the DOM. */
+   or absent; set to its real width on body.has-left-panel below. Part of the
+   consumer contract in docs/plugins.rst, "Frontend Overlays". */
 :root {
   --left-panel-width: 0px;
 }
@@ -36,10 +36,10 @@ body {
   overflow: hidden;
 }
 
-/* Portal target for overlays (toasts, dialogs) that must escape #main-row's
-   stacking context. Spans the content area horizontally, but the full viewport
-   vertically (the navbar's height is content-dependent) - so a child sized to
-   the layer covers the navbar and steals its clicks. */
+/* Portal target for overlays that must escape #main-row's stacking context.
+   Full viewport height because the navbar's height is content-dependent and
+   not expressible here. Consumer contract: docs/plugins.rst, "Frontend
+   Overlays". */
 #overlay-root {
   position: fixed;
   top: 0;

--- a/platzky/static/styles.css
+++ b/platzky/static/styles.css
@@ -173,9 +173,9 @@ main {
 }
 
 @media only screen and (min-width: 992px) {
-  /* Above this breakpoint the panel stops being an offcanvas overlay and takes
-     up real width in the layout, which #overlay-root has to skip. Internal to
-     this stylesheet - not part of the documented plugin contract. */
+  /* Only at this breakpoint does the panel occupy layout width (below it,
+     Bootstrap's offcanvas floats over the content at zero width), so only
+     here may --left-panel-width be non-zero. */
   body:has(#left-panel) {
     --left-panel-width: 220px;
   }

--- a/platzky/static/styles.css
+++ b/platzky/static/styles.css
@@ -1,3 +1,10 @@
+/* Layout width of the left panel: 0 while it is an offcanvas overlay (<992px)
+   or absent; set to its real width on body.has-left-panel below. Offset against
+   the content area with this instead of measuring the DOM. */
+:root {
+  --left-panel-width: 0px;
+}
+
 html {
   height: 100%;
   overflow: hidden;
@@ -22,8 +29,31 @@ body {
 #main-row {
   position: relative;
   flex-grow: 1;
+  /* Contains the content area's z-indexes (e.g. Leaflet panes at 400-800) so
+     they cannot paint over the navbar - do not remove. Overlays that must
+     escape this stacking context portal into #overlay-root instead. */
   z-index: 0;
   overflow: hidden;
+}
+
+/* Portal target for overlays (toasts, dialogs) that must escape #main-row's
+   stacking context. Spans the content area horizontally, but the full viewport
+   vertically (the navbar's height is content-dependent) - so a child sized to
+   the layer covers the navbar and steals its clicks. */
+#overlay-root {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  inset-inline-start: var(--left-panel-width);
+  inset-inline-end: 0;
+  /* Above Bootstrap's modal (1055) and MUI's Dialog (1300). */
+  z-index: 2000;
+  pointer-events: none;
+}
+
+/* The layer must not swallow clicks on content under it; children opt back in. */
+#overlay-root > * {
+  pointer-events: auto;
 }
 
 /* Main content area scrolling */
@@ -141,11 +171,17 @@ main {
 }
 
 @media only screen and (min-width: 992px) {
+  /* Above this breakpoint the panel stops being an offcanvas overlay and takes
+     up real width in the layout. */
+  body.has-left-panel {
+    --left-panel-width: 220px;
+  }
+
   #left-panel {
     position: relative;
-    inline-size: 220px;
-    max-width: 220px;
-    width: 220px;
+    inline-size: var(--left-panel-width);
+    max-width: var(--left-panel-width);
+    width: var(--left-panel-width);
     display: flex;
     flex-direction: column;
     max-height: 100%;
@@ -167,6 +203,8 @@ main {
   width: auto;
 }
 
+/* Enough for the navbar dropdown, which only competes with #main-row's 0. A
+   dropdown inside #main-row would lose to content z-indexes at this value. */
 .dropdown-menu {
   z-index: 1;
 }

--- a/platzky/templates/base.html
+++ b/platzky/templates/base.html
@@ -31,7 +31,11 @@
 
   {% block structured_data %}{% endblock %}
 </head>
-<body>
+<body{% if self.left_panel() %} class="has-left-panel"{% endif %}>
+{# Portal target for overlays; see #overlay-root in styles.css. First in body so
+   it exists before any script runs, including plugin markup from body_meta. #}
+<div id="overlay-root"></div>
+
 {% block body_meta %}
 {% include "body_meta.html" %}
 {% endblock %}

--- a/platzky/templates/base.html
+++ b/platzky/templates/base.html
@@ -32,8 +32,9 @@
   {% block structured_data %}{% endblock %}
 </head>
 <body{% if self.left_panel() %} class="has-left-panel"{% endif %}>
-{# Portal target for overlays; see #overlay-root in styles.css. First in body so
-   it exists before any script runs, including plugin markup from body_meta. #}
+{# Overlay portal target; keep as the first element of <body> so body scripts,
+   including plugin markup from body_meta, can rely on it existing. Consumer
+   contract: docs/plugins.rst, "Frontend Overlays". #}
 <div id="overlay-root"></div>
 
 {% block body_meta %}

--- a/platzky/templates/base.html
+++ b/platzky/templates/base.html
@@ -31,7 +31,7 @@
 
   {% block structured_data %}{% endblock %}
 </head>
-<body{% if self.left_panel() %} class="has-left-panel"{% endif %}>
+<body>
 {# Overlay portal target; keep as the first element of <body> so body scripts,
    including plugin markup from body_meta, can rely on it existing. Consumer
    contract: docs/plugins.rst, "Frontend Overlays". #}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated overlay layer for dropdowns and other floating interface elements above page content.
  * Improved overlay positioning and interaction behavior, including support for layouts with a left-side panel.
  * Enabled overlays to remain visually accessible while allowing normal page interactions outside active elements.
* **Documentation**
  * Documented overlay placement, stacking, pointer interactions, sizing conventions, and left-panel layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->